### PR TITLE
Fix comment to reflect ridge loss function usage

### DIFF
--- a/dsbook/supervised/regularization.ipynb
+++ b/dsbook/supervised/regularization.ipynb
@@ -81,7 +81,7 @@
     "    l2_penalty = alpha * np.sum(params**2)\n",
     "    return residual_sum_squares + l2_penalty\n",
     "\n",
-    "# Optimize the parameters of our model using the lasso loss function\n",
+    "# Optimize the parameters of our model using the ridge loss function\n",
     "result_poly_rss = minimize_loss(rss_loss, polynomial_model, x, y_non_linear,8)\n",
     "result_poly_ridge = minimize_loss(ridge_loss, polynomial_model, x, y_non_linear,8)\n",
     "\n",


### PR DESCRIPTION
A comment under the code block for ridge loss using scikit said that we use the "lasso loss" function. This has been changed to "ridge loss".